### PR TITLE
Fix reservations and cast pages

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -7,12 +7,13 @@ import TableStatusPage from './pages/TableStatusPage';
 import ReservationPage from './pages/ReservationPage';
 import AdminDashboard from './pages/AdminDashboard';
 import CastDashboard from './pages/CastDashboard';
+import CastListPage from './pages/CastListPage';
+import AdminTableSettings from './pages/AdminTableSettings';
 
 const AppRoutes: React.FC = () => {
   const location = useLocation();
   const { stores, currentStore } = useStore();
   const { state: { currentUser: user } } = useAppContext();
-  const defaultId = stores.length > 0 ? stores[0].id : '';
 
   useEffect(() => {
     console.log('現在のパス:', location.pathname);
@@ -23,20 +24,13 @@ const AppRoutes: React.FC = () => {
 
   return (
     <Routes>
-      <Route
-        path="/"
-        element={
-          defaultId ? (
-            <Navigate to={`/stores/${defaultId}`} replace />
-          ) : (
-            <div>店舗が見つかりません。管理者にお問い合わせください。</div>
-          )
-        }
-      />
+      <Route path="/" element={<Navigate to="/tables" replace />} />
       <Route path="/stores/:subdomain" element={<AdminDashboard />} />
       <Route path="/cast/:subdomain" element={<CastDashboard />} />
       <Route path="/tables" element={<TableStatusPage />} />
       <Route path="/reservations" element={<ReservationPage />} />
+      <Route path="/casts" element={<CastListPage />} />
+      <Route path="/settings" element={<AdminTableSettings />} />
     </Routes>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { useStore } from '../context/StoreContext';
 
 const Header: React.FC = () => {
-  const { currentStore, isEmployeeView } = useStore();
+  const { currentStore } = useStore();
 
-  if (!isEmployeeView || !currentStore) return null;
+  if (!currentStore) return null;
 
   return (
     <header className="bg-white shadow p-4 text-xl font-semibold">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,22 +2,16 @@
 import React from 'react';
 import Header from './Header';
 import Footer from './Footer';
-import { useStore } from '../context/StoreContext';
 
 interface LayoutProps {
   children: React.ReactNode;
 }
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
-  const { isEmployeeView } = useStore();
-
   return (
     <div className="flex flex-col min-h-screen">
-      {/* 従業員画面でのみヘッダー表示 */}
-      {isEmployeeView && <Header />}
-      <main className="flex-grow container mx-auto px-4 py-6">
-        {children}
-      </main>
+      <Header />
+      <main className="flex-grow container mx-auto px-4 py-6">{children}</main>
       <Footer />
     </div>
   );

--- a/src/pages/AdminTableSettings.tsx
+++ b/src/pages/AdminTableSettings.tsx
@@ -8,7 +8,7 @@ type TableSetting = string;
 
 interface AdminTableSettingsProps {
   /** AppInner から渡される、AppInner の currentUser state をクリアするための関数 */
-  setCurrentUser: (user: User | null) => void;
+  setCurrentUser?: (user: User | null) => void;
 }
 
 const AdminTableSettings: React.FC<AdminTableSettingsProps> = ({ setCurrentUser }) => {
@@ -25,7 +25,7 @@ const AdminTableSettings: React.FC<AdminTableSettingsProps> = ({ setCurrentUser 
   // ログアウト
   const handleLogout = useCallback(() => {
     // AppInner のローカル currentUser state をクリア
-    setCurrentUser(null);
+    setCurrentUser?.(null);
     // Context 側にもユーザー情報をクリア
     dispatch({ type: 'SET_USER', payload: null });
     // ログイン画面へリダイレクト（履歴を置き換え）

--- a/src/pages/CastListPage.tsx
+++ b/src/pages/CastListPage.tsx
@@ -1,7 +1,6 @@
 // src/pages/CastListPage.tsx
 
 import React, { useState, useEffect, useRef } from 'react'
-import { useSearchParams } from 'react-router-dom'
 import { v4 as uuidv4 } from 'uuid'
 
 interface Invite {
@@ -11,7 +10,6 @@ interface Invite {
 }
 
 export default function CastListPage() {
-  const [searchParams, setSearchParams] = useSearchParams()
   const [invites, setInvites] = useState<Invite[]>(() => {
     const saved = localStorage.getItem('invites')
     return saved ? JSON.parse(saved) : []
@@ -19,13 +17,6 @@ export default function CastListPage() {
   const [modalOpen, setModalOpen] = useState(false)
   const firstShareButtonRef = useRef<HTMLButtonElement>(null)
 
-  // URLクエリに ?openModal=true があればモーダルを開く
-  useEffect(() => {
-    if (searchParams.get('openModal') === 'true') {
-      setModalOpen(true)
-      setSearchParams({})
-    }
-  }, [searchParams, setSearchParams])
 
   // invites を localStorage に永続化
   useEffect(() => {
@@ -92,9 +83,15 @@ export default function CastListPage() {
   return (
     <div className="p-4 pb-16">
       {/* 見出し */}
-      <h2 className="text-2xl font-bold mb-4 text-center">
-        在籍キャスト一覧
-      </h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-2xl font-bold text-center flex-grow">在籍キャスト一覧</h2>
+        <button
+          onClick={() => setModalOpen(true)}
+          className="ml-2 px-3 py-1 bg-blue-500 text-white rounded"
+        >
+          追加
+        </button>
+      </div>
 
       {/* 発行済みリンク一覧 */}
       <ul className="space-y-4">

--- a/src/pages/ReservationPage.tsx
+++ b/src/pages/ReservationPage.tsx
@@ -6,7 +6,7 @@ import React, {
   type ChangeEvent,
   type KeyboardEvent,
 } from 'react'
-import { useAppContext, type Reservation, type User } from '../context/AppContext'
+import { useAppContext, type Reservation } from '../context/AppContext'
 
 // 19:00～25:00 を15分刻みで生成
 const generateTimeOptions = (): string[] => {
@@ -23,18 +23,9 @@ const generateTimeOptions = (): string[] => {
 }
 const timeOptions = generateTimeOptions()
 
-interface Props {
-  isOpen: boolean
-  onClose: () => void
-  currentUser: User | null
-}
-
-export default function ReservationPage({
-  isOpen,
-  onClose,
-  currentUser,
-}: Props) {
+export default function ReservationPage() {
   const { state, dispatch } = useAppContext()
+  const currentUser = state.currentUser
   const { reservations, tableSettings = [], tables } = state
 
   // 使用中の卓番号リスト
@@ -48,6 +39,7 @@ export default function ReservationPage({
     'undecided'
   )
   const [budget, setBudget] = useState<number | ''>('')
+  const [isOpen, setIsOpen] = useState(false)
   const [errors, setErrors] = useState<{
     princess?: string
     budget?: string
@@ -66,7 +58,7 @@ export default function ReservationPage({
 
   // ESC で閉じる
   const handleKeyDown = (e: KeyboardEvent<HTMLElement>) => {
-    if (e.key === 'Escape') onClose()
+    if (e.key === 'Escape') setIsOpen(false)
   }
 
   // 卓反映モーダル state
@@ -107,7 +99,7 @@ export default function ReservationPage({
     setBudgetMode('undecided')
     setBudget('')
     setErrors({})
-    onClose()
+    setIsOpen(false)
   }
 
   // 予約削除（確認＋メッセージ）
@@ -206,7 +198,15 @@ export default function ReservationPage({
         className="p-4 pb-16"
         onKeyDown={handleKeyDown}
       >
-        <h2 className="text-2xl font-bold mb-4 text-center">来店予約表</h2>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-2xl font-bold text-center flex-grow">来店予約表</h2>
+          <button
+            onClick={() => setIsOpen(true)}
+            className="ml-2 px-3 py-1 bg-blue-500 text-white rounded"
+          >
+            追加
+          </button>
+        </div>
 
         {/* 追加モーダル */}
         {isOpen && (
@@ -294,7 +294,7 @@ export default function ReservationPage({
 
               <div className="flex justify-end space-x-2">
                 <button
-                  onClick={onClose}
+                  onClick={() => setIsOpen(false)}
                   className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400"
                 >
                   キャンセル


### PR DESCRIPTION
## Summary
- show header/footer on all logged-in pages
- reroute app startup to table view
- add routes for settings and cast list
- open reservation modal from ReservationPage
- open invite modal from CastListPage
- make AdminTableSettings props optional

## Testing
- `npm test --silent` *(fails: jest not found)*