### PR TITLE
Fix reservation context types

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -7,14 +7,14 @@ export interface User {
   username: string;
   role: Role;
   /**
-   * Optional flag used on the reservation page to determine
-   * whether the user can reflect reservations onto tables.
+   * Flag used on the reservation page to determine whether the
+   * user can reflect reservations onto tables.
    */
-  canManageTables?: boolean;
+  canManageTables: boolean;
 }
 
 export interface Reservation {
-  id: number;
+  id: string;
   princess: string;
   requestedTable: string;
   time: string;
@@ -46,11 +46,11 @@ type Action =
   | { type: 'ADD_TABLE_SETTING'; payload: string }
   | { type: 'REMOVE_TABLE_SETTING'; payload: string }
   | { type: 'ADD_RESERVATION'; payload: Reservation }
-  | { type: 'DELETE_RESERVATION'; payload: number }
+  | { type: 'DELETE_RESERVATION'; payload: string }
   | {
       type: 'ASSIGN_TABLE';
       payload: {
-        id: number;
+        id: string;
         requestedTable: string;
         princess: string;
         budget: number;
@@ -62,6 +62,7 @@ const initialState: AppState = {
   currentUser: {
     username: 'admin',
     role: 'owner', // 初期値。必要に応じて 'cast' などに変更
+    canManageTables: true,
   },
   tables: [],
   tableSettings: [],
@@ -116,7 +117,7 @@ const reducer = (state: AppState, action: Action): AppState => {
         tables: [
           ...state.tables,
           {
-            id: String(action.payload.id),
+            id: action.payload.id,
             tableNumber: action.payload.requestedTable,
             princess: action.payload.princess,
             budget: action.payload.budget,

--- a/src/pages/AdminTableSettings.tsx
+++ b/src/pages/AdminTableSettings.tsx
@@ -27,7 +27,7 @@ const AdminTableSettings: React.FC<AdminTableSettingsProps> = ({ setCurrentUser 
     // AppInner のローカル currentUser state をクリア
     setCurrentUser?.(null);
     // Context 側にもユーザー情報をクリア
-    dispatch({ type: 'SET_USER', payload: null });
+    dispatch({ type: 'LOGOUT' });
     // ログイン画面へリダイレクト（履歴を置き換え）
     navigate('/', { replace: true });
   }, [setCurrentUser, dispatch, navigate]);

--- a/src/pages/CastDashboard.tsx
+++ b/src/pages/CastDashboard.tsx
@@ -10,7 +10,7 @@ function CastDashboard() {
   const user = state.currentUser;
 
   const handleLogout = () => {
-    dispatch({ type: 'SET_USER', payload: null });
+    dispatch({ type: 'LOGOUT' });
     navigate('/');
   };
 

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -18,7 +18,7 @@ export default function MyPage({ setCurrentUser }: MyPageProps) {
     // App.tsx のローカル state をクリア
     setCurrentUser(null)
     // Context state もクリア
-    dispatch({ type: 'SET_USER', payload: null })
+    dispatch({ type: 'LOGOUT' })
     // ログイン画面へリダイレクト
     navigate('/')
   }

--- a/src/pages/PrincessListPage.tsx
+++ b/src/pages/PrincessListPage.tsx
@@ -60,7 +60,7 @@ export default function ReservationPage({ isOpen, onClose, currentUser }: Props)
     dispatch({
       type: 'ADD_RESERVATION',
       payload: {
-        id: Date.now(),
+        id: Date.now().toString(),
         princess: princess.trim(),
         requestedTable: requestedTable.trim(),
         budget: Number(budget),

--- a/src/pages/ReservationPage.tsx
+++ b/src/pages/ReservationPage.tsx
@@ -86,7 +86,7 @@ export default function ReservationPage() {
     dispatch({
       type: 'ADD_RESERVATION',
       payload: {
-        id: Date.now(),
+        id: Date.now().toString(),
         princess: princess.trim(),
         requestedTable: requestedTable.trim(),
         time: plannedTime,
@@ -103,7 +103,7 @@ export default function ReservationPage() {
   }
 
   // 予約削除（確認＋メッセージ）
-  const handleReservationDelete = (id: number, name: string) => {
+  const handleReservationDelete = (id: string, name: string) => {
     if (!window.confirm(`本当に ${name} さんの予約を削除しますか？`)) return
     dispatch({ type: 'DELETE_RESERVATION', payload: id })
     setDeleteMessage(`${name} さんの予約を削除しました`)


### PR DESCRIPTION
## Summary
- add `Reservation` type and reservation actions in context
- ensure `User` includes `canManageTables`
- update logout logic to use `LOGOUT` action
- use string ids for reservations

## Testing
- `npm run lint` *(fails: ignorePatterns not supported)*
- `npm test` *(fails: jest not found)*