### PR TITLE
Enable session restore and role redirects

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -11,7 +11,27 @@ import AdminTableSettings from './pages/AdminTableSettings'
 import ChatPage from './pages/ChatPage'
 import Register from './pages/Register'
 import ProtectedRoute from './components/ProtectedRoute'
-import NotAuthorized from './pages/NotAuthorized' // ✅ 追加
+import NotAuthorized from './pages/NotAuthorized'
+
+const HomeRedirect: React.FC = () => {
+  const {
+    state: { session, supabaseUser },
+  } = useAppContext()
+
+  if (session && supabaseUser) {
+    const role = (supabaseUser.user_metadata as any).role
+    const storeId = (supabaseUser.user_metadata as any).store_id
+
+    if (['admin', 'owner', 'operator'].includes(role)) {
+      return <Navigate to={`/stores/${storeId}`} replace />
+    }
+    if (role === 'cast') {
+      return <Navigate to={`/cast/${storeId}`} replace />
+    }
+  }
+
+  return <Navigate to="/register" replace />
+}
 
 const AppRoutes: React.FC = () => {
   const location = useLocation()
@@ -29,7 +49,7 @@ const AppRoutes: React.FC = () => {
 
   return (
     <Routes>
-      <Route path="/" element={<Navigate to="/tables" replace />} />
+      <Route path="/" element={<HomeRedirect />} />
       <Route path="/register" element={<Register />} />
 
       <Route


### PR DESCRIPTION
## Summary
- restore Supabase session on app load and track user in context
- listen for auth state changes to keep session info
- send `/` requests to the appropriate dashboard based on role

## Testing
- `npm test` *(fails: `jest` not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_68441b66f9148332bbdb93d0eca13698